### PR TITLE
PHP 5.5+ curl support

### DIFF
--- a/application/libraries/Languages.php
+++ b/application/libraries/Languages.php
@@ -160,7 +160,7 @@ class Languages {
     function POEditor_Extract() {
 	$path   = FCPATH;
 	$pofile = APPPATH.$this->config['gettext_locale_dir'] . DIRECTORY_SEPARATOR . $this->CI->config->item('domain') . '.pot';
-	$cmd = "cd /tmp ; echo '' > messages.po ; find $path -type f -iname \"*.php\" | xgettext --keyword=_ --keyword=_e -j -f - ; mv messages.po $pofile";
+	$cmd = "cd /tmp ; echo '' > messages.po ; find $path -type f -iname \"*.php\" | xgettext --from-code=" . $this->config['gettext_catalog_codeset'] . " --keyword=_ --keyword=_e -j -f - ; mv messages.po $pofile";
 	exec($cmd);
     }
     

--- a/application/libraries/Languages.php
+++ b/application/libraries/Languages.php
@@ -160,7 +160,7 @@ class Languages {
     function POEditor_Extract() {
 	$path   = FCPATH;
 	$pofile = APPPATH.$this->config['gettext_locale_dir'] . DIRECTORY_SEPARATOR . $this->CI->config->item('domain') . '.pot';
-	$cmd = "cd /tmp ; echo '' > messages.po ; find $path -type f -iname \"*.php\" | xgettext --from-code=" . $this->config['gettext_catalog_codeset'] . " --keyword=_:1,2c --keyword=_e:1,2c -j -f - ; mv messages.po $pofile";
+	$cmd = "cd /tmp ; echo '' > messages.po ; find $path -type f -iname \"*.php\" | xgettext --keyword=_ --keyword=_e -j -f - ; mv messages.po $pofile";
 	exec($cmd);
     }
     

--- a/application/libraries/Languages.php
+++ b/application/libraries/Languages.php
@@ -160,7 +160,7 @@ class Languages {
     function POEditor_Extract() {
 	$path   = FCPATH;
 	$pofile = APPPATH.$this->config['gettext_locale_dir'] . DIRECTORY_SEPARATOR . $this->CI->config->item('domain') . '.pot';
-	$cmd = "cd /tmp ; echo '' > messages.po ; find $path -type f -iname \"*.php\" | xgettext --keyword=_ --keyword=_e -j -f - ; mv messages.po $pofile";
+	$cmd = "cd /tmp ; echo '' > messages.po ; find $path -type f -iname \"*.php\" | xgettext --from-code=" . $this->config['gettext_catalog_codeset'] . " --keyword=_:1,2c --keyword=_e:1,2c -j -f - ; mv messages.po $pofile";
 	exec($cmd);
     }
     

--- a/application/libraries/Languages.php
+++ b/application/libraries/Languages.php
@@ -216,8 +216,9 @@ class Languages {
 	    return false;
 	}
     
+    $file = class_exists('CurlFile', false) ? new CURLFile($pofile, 'application/octet-stream') : "@{$pofile}"; // PHP 5.5 dropped support for the ‘@’ in CURL params 
 	$params  = array('id'         => $project,
-			 'file'       =>  '@' . $pofile,
+			 'file'       =>  $file,
 			 'updating'   => 'terms',
 			 'sync_terms' => 1);
 	


### PR DESCRIPTION
As pointed out by Adrian Basalic from POEditor.com, PHP 5.5+ dropped support for '@' in curl parameters. You now have to use CurlFile instead. This commit ensure it will work will any version of PHP
